### PR TITLE
Adding repo to package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "author": "Andrew Chilton",
   "license": "ISC",
+  "repository": "chilts/seagull",
   "dependencies": {
     "async": "^1.2.0",
     "data2xml": "^1.2.1",


### PR DESCRIPTION
Now https://npmjs.org/seagull can link to the GitHub repo.